### PR TITLE
EE-32c: fix loading of type and milestone field values

### DIFF
--- a/src/app/project/certificates/certificates-resolver.service.ts
+++ b/src/app/project/certificates/certificates-resolver.service.ts
@@ -27,7 +27,7 @@ export class CertificatesResolver implements Resolve<Observable<object>> {
         // Search only Certificate Package/EAO/Certificate
         documentSource: 'PROJECT',
         type: '5cf00c03a266b7e1877504d5',
-        documentAuthor: '5cf00c03a266b7e1877504db',
+        documentAuthorType: '5cf00c03a266b7e1877504db',
         milestone: '5cf00c03a266b7e1877504eb'
       },
       true);

--- a/src/app/project/documents/project-document-table-rows/project-document-table-rows.component.ts
+++ b/src/app/project/documents/project-document-table-rows/project-document-table-rows.component.ts
@@ -42,7 +42,7 @@ export class DocumentTableRowsComponent implements OnInit, OnDestroy, TableCompo
       .subscribe((res: any) => {
         if (res) {
           if (res.documentsTableRow && res.documentsTableRow.length > 0) {
-            this.lists = res.documentsTableRow;
+            this.lists = res.documentsTableRow[0].searchResults;
           } else if (res.documents && res.documents.length > 0) {
             this.lists = res.documents[0].data.searchResults;
           } else {

--- a/src/app/project/project-routes.ts
+++ b/src/app/project/project-routes.ts
@@ -32,14 +32,16 @@ export const ProjectRoutes: Routes = [
     path: 'certificates',
     component: CertificatesComponent,
     resolve: {
-      documents: CertificatesResolver
+      documents: CertificatesResolver,
+      documentsTableRow: DocumentTableResolver
     }
   },
   {
     path: 'amendments',
     component: CertificatesComponent,
     resolve: {
-      documents: AmendmentsResolverService
+      documents: AmendmentsResolverService,
+      documentsTableRow: DocumentTableResolver
     }
   },
   {


### PR DESCRIPTION
**Documents & Amendments** tab: update table-rows so type and milestone fields populate correctly

**Certificates** tab: fix data loading by updating the search params to use documentAuthorType, and use the resolver to populate field values