### PR TITLE
fix type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/geojson": "^7946.0.2",
     "@types/leaflet": "^1.2.6",
     "@types/leaflet.markercluster": "^1.0.3",
-    "@types/moment-timezone": "^0.5.12",
     "bootstrap": "^4.3.1",
     "classlist.js": "^1.1.20150312",
     "core-js": "^2.5.3",


### PR DESCRIPTION
remove type warning breaking build, in the future we could consider adding @types/moment-timezone back in and fixing type errors