### PR TITLE
Routes as settings2

### DIFF
--- a/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
+++ b/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
@@ -227,14 +227,14 @@
     {
       "name": "REAL_IP_FROM",
       "displayName": "OpenShift Cluster IP Range",
-      "description": "OpenShift cluster private IP range in CIDR notation, used by Nginx ngx_http_realip_module. Requires rebuild of nginx-runtime to take effect.",
+      "description": "OpenShift cluster private IP range in CIDR notation, used by Nginx ngx_http_realip_module.",
       "required": true,
       "value": "172.51.0.0/16"
     },
     {
       "name": "AdditionalRealIpFromRules",
       "displayName": "Additional real_ip_from Rules",
-      "description": "Additional known and trusted reverse proxy ips conforming to nginx set_real_ip_from directive syntax. Multiple directives are allowed, separated by semicolon. Requires rebuild of nginx-runtime to take effect."
+      "description": "Additional known and trusted reverse proxy ips conforming to nginx set_real_ip_from directive syntax. Multiple directives are allowed, separated by semicolon."
     },
     {
       "name": "IpFilterRules",
@@ -251,19 +251,19 @@
     {
       "name": "TAG_NAME",
       "displayName": "Env TAG name",
-      "description": "The TAG name for this environment, e.g., dev, test, prod. Requires rebuild of nginx-runtime to take effect.",
+      "description": "The TAG name for this environment, e.g., dev, test, prod.",
       "value": "your-openshift-tag"
     },
     {
       "name": "REMOTE_API_PATH",
       "displayName": "URL path to API",
-      "description": "The 'https://' prefixed URL path to the API the public Angular app will make calls to. Requires rebuild of nginx-runtime to take effect.",
+      "description": "The 'https://' prefixed URL path to the API the public Angular app will make calls to.",
       "value": "https://eagle-your-openshift-namespace.pathfinder.gov.bc.ca/api/public"
     },
     {
       "name": "REMOTE_ADMIN_PATH",
       "displayName": "URL path to Admin",
-      "description": "The 'https://' prefixed URL path to the Admin app that the public Angular app will link to.  Note that the trailing slash is required. Requires rebuild of nginx-runtime to take effect.",
+      "description": "The 'https://' prefixed URL path to the Admin app that the public Angular app will link to.  Note that the trailing slash is required.",
       "value": "https://eagle-your-openshift-namespace.pathfinder.gov.bc.ca/admin/"
     }
   ]

--- a/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
+++ b/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
@@ -227,19 +227,19 @@
     {
       "name": "REAL_IP_FROM",
       "displayName": "OpenShift Cluster IP Range",
-      "description": "OpenShift cluster private IP range in CIDR notation, used by Nginx ngx_http_realip_module.",
+      "description": "OpenShift cluster private IP range in CIDR notation, used by Nginx ngx_http_realip_module. Requires rebuild of nginx-runtime to take effect.",
       "required": true,
       "value": "172.51.0.0/16"
     },
     {
       "name": "AdditionalRealIpFromRules",
       "displayName": "Additional real_ip_from Rules",
-      "description": "Additional known and trusted reverse proxy ips conforming to nginx set_real_ip_from directive syntax. Multiple directives are allowed, separated by semicolon."
+      "description": "Additional known and trusted reverse proxy ips conforming to nginx set_real_ip_from directive syntax. Multiple directives are allowed, separated by semicolon. Requires rebuild of nginx-runtime to take effect."
     },
     {
       "name": "IpFilterRules",
       "displayName": "Ip Filter Rules",
-      "description": "Nginx ngx_http_access_module ip filter rules",
+      "description": "Nginx ngx_http_access_module ip filter rules. Requires rebuild of nginx-runtime to take effect.",
       "value": "#allow all; deny all;"
     },
     {
@@ -251,20 +251,20 @@
     {
       "name": "TAG_NAME",
       "displayName": "Env TAG name",
-      "description": "The TAG name for this environment, e.g., dev, test, prod",
+      "description": "The TAG name for this environment, e.g., dev, test, prod. Requires rebuild of nginx-runtime to take effect.",
       "value": "your-openshift-tag"
     },
     {
       "name": "REMOTE_API_PATH",
       "displayName": "URL path to API",
-      "description": "The URL path to the API the public Angular app will make calls to",
-      "value": "eagle-your-openshift-namespace.pathfinder.gov.bc.ca/api/public"
+      "description": "The 'https://' prefixed URL path to the API the public Angular app will make calls to. Requires rebuild of nginx-runtime to take effect.",
+      "value": "https://eagle-your-openshift-namespace.pathfinder.gov.bc.ca/api/public"
     },
     {
       "name": "REMOTE_ADMIN_PATH",
       "displayName": "URL path to Admin",
-      "description": "The URL path to the Admin app that the public Angular app will link to.  Note that the trailing slash is required.",
-      "value": "eagle-your-openshift-namespace.pathfinder.gov.bc.ca/admin/"
+      "description": "The 'https://' prefixed URL path to the Admin app that the public Angular app will link to.  Note that the trailing slash is required. Requires rebuild of nginx-runtime to take effect.",
+      "value": "https://eagle-your-openshift-namespace.pathfinder.gov.bc.ca/admin/"
     }
   ]
 }

--- a/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
+++ b/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
@@ -263,7 +263,7 @@
     {
       "name": "REMOTE_ADMIN_PATH",
       "displayName": "URL path to Admin",
-      "description": "The URL path to the Admin app that the public Angular app will make calls to.  Note that the trailing slash is required.",
+      "description": "The URL path to the Admin app that the public Angular app will link to.  Note that the trailing slash is required.",
       "value": "eagle-your-openshift-namespace.pathfinder.gov.bc.ca/admin/"
     }
   ]

--- a/openshift/templates/nginx-runtime/Dockerfile
+++ b/openshift/templates/nginx-runtime/Dockerfile
@@ -4,9 +4,9 @@ LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 COPY nginx.conf.template /tmp/
 COPY default.conf /etc/nginx/conf.d/
 RUN mkdir -p /etc/nginx/
-RUN echo "" > /etc/nginx/serverEnvironmentSettings.js
+RUN echo "" > /etc/nginx/publicServerEnvironmentSettings.js
 RUN mkdir -p /tmp/app/dist/
-RUN ln -sf /etc/nginx/serverEnvironmentSettings.js /tmp/app/dist/serverEnvironmentSettings.js
+RUN ln -sf /etc/nginx/publicServerEnvironmentSettings.js /tmp/app/dist/publicServerEnvironmentSettings.js
 RUN chmod -R 0777 /tmp /var /run /etc /mnt /usr/libexec/s2i/
 EXPOSE 8080
 USER 104

--- a/openshift/templates/nginx-runtime/Dockerfile
+++ b/openshift/templates/nginx-runtime/Dockerfile
@@ -3,6 +3,10 @@ COPY ./s2i/bin/ /usr/libexec/s2i/
 LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 COPY nginx.conf.template /tmp/
 COPY default.conf /etc/nginx/conf.d/
+RUN mkdir -p /etc/nginx/
+RUN echo "" > /etc/nginx/serverEnvironmentSettings.js
+RUN mkdir -p /tmp/app/dist/
+RUN ln -sf /etc/nginx/serverEnvironmentSettings.js /tmp/app/dist/serverEnvironmentSettings.js
 RUN chmod -R 0777 /tmp /var /run /etc /mnt /usr/libexec/s2i/
 EXPOSE 8080
 USER 104

--- a/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/openshift/templates/nginx-runtime/s2i/bin/run
@@ -2,9 +2,9 @@
 echo run script starting...
 sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
 
-echo "window.localStorage.setItem('on_public_server--remote_api_path', '${REMOTE_API_PATH:-set-in-project-nginx-runtime}');" > /etc/nginx/publicServerEnvironmentSettings.js;
-echo "window.localStorage.setItem('on_public_server--remote_admin_path', '${REMOTE_ADMIN_PATH:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
-echo "window.localStorage.setItem('on_public_server--deployment_env', '${DEPLOYMENT_ENVIRONMENT:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
+echo "window.localStorage.setItem('from_public_server--remote_api_path', '${REMOTE_API_PATH:-set-in-project-nginx-runtime}');" > /etc/nginx/publicServerEnvironmentSettings.js;
+echo "window.localStorage.setItem('from_public_server--remote_admin_path', '${REMOTE_ADMIN_PATH:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
+echo "window.localStorage.setItem('from_public_server--deployment_env', '${DEPLOYMENT_ENVIRONMENT:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
 
 if [ -n "$HTTP_BASIC_USERNAME" ] && [ -n "$HTTP_BASIC_PASSWORD" ]; then
     echo "---> Generating .htpasswd file"

--- a/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/openshift/templates/nginx-runtime/s2i/bin/run
@@ -2,9 +2,9 @@
 echo run script starting...
 sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
 
-echo "window.localStorage.setItem('remote_api_path', '${REMOTE_API_PATH:-set-in-project-nginx-runtime}');" > /etc/nginx/serverEnvironmentSettings.js;
-echo "window.localStorage.setItem('remote_admin_path', '${REMOTE_ADMIN_PATH:-set-in-project-nginx-runtime}');" >> /etc/nginx/serverEnvironmentSettings.js;
-echo "window.localStorage.setItem('deployment_env', '${DEPLOYMENT_ENVIRONMENT:-set-in-project-nginx-runtime}');" >> /etc/nginx/serverEnvironmentSettings.js;
+echo "window.localStorage.setItem('on_public_server--remote_api_path', '${REMOTE_API_PATH:-set-in-project-nginx-runtime}');" > /etc/nginx/publicServerEnvironmentSettings.js;
+echo "window.localStorage.setItem('on_public_server--remote_admin_path', '${REMOTE_ADMIN_PATH:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
+echo "window.localStorage.setItem('on_public_server--deployment_env', '${DEPLOYMENT_ENVIRONMENT:-set-in-project-nginx-runtime}');" >> /etc/nginx/publicServerEnvironmentSettings.js;
 
 if [ -n "$HTTP_BASIC_USERNAME" ] && [ -n "$HTTP_BASIC_PASSWORD" ]; then
     echo "---> Generating .htpasswd file"

--- a/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/openshift/templates/nginx-runtime/s2i/bin/run
@@ -2,6 +2,10 @@
 echo run script starting...
 sed "s~%RealIpFrom%~${RealIpFrom:-172.51.0.0/16}~g; s~%IpFilterRules%~${IpFilterRules}~g; s~%AdditionalRealIpFromRules%~${AdditionalRealIpFromRules}~g" /tmp/nginx.conf.template > /etc/nginx/nginx.conf
 
+echo "window.localStorage.setItem('remote_api_path', '${REMOTE_API_PATH:-set-in-project-nginx-runtime}');" > /etc/nginx/serverEnvironmentSettings.js;
+echo "window.localStorage.setItem('remote_admin_path', '${REMOTE_ADMIN_PATH:-set-in-project-nginx-runtime}');" >> /etc/nginx/serverEnvironmentSettings.js;
+echo "window.localStorage.setItem('deployment_env', '${DEPLOYMENT_ENVIRONMENT:-set-in-project-nginx-runtime}');" >> /etc/nginx/serverEnvironmentSettings.js;
+
 if [ -n "$HTTP_BASIC_USERNAME" ] && [ -n "$HTTP_BASIC_PASSWORD" ]; then
     echo "---> Generating .htpasswd file"
     `echo "$HTTP_BASIC_USERNAME:$(openssl passwd -crypt $HTTP_BASIC_PASSWORD)" > /tmp/.htpasswd`

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -25,7 +25,8 @@ export class ApiService {
   public isMS: boolean; // IE, Edge, etc
   public apiPath: string;
   public adminUrl: string;
-  public env: 'local' | 'dev' | 'test' | 'prod' | 'demo';
+  public env: string;  // Could be anything per Openshift settings but generally is one of 'local' | 'dev' | 'test' | 'prod' | 'demo'
+
 
   constructor(
     private http: HttpClient,
@@ -34,53 +35,16 @@ export class ApiService {
     // const currentUser = JSON.parse(window.localStorage.getItem('currentUser'));
     // this.token = currentUser && currentUser.token;
     this.isMS = window.navigator.msSaveOrOpenBlob ? true : false;
-    const { hostname } = window.location;
-    switch (hostname) {
-      case 'localhost':
-        // Local
-        this.apiPath = 'http://localhost:3000/api/public';
-        this.adminUrl = 'http://localhost:4200';
-        this.env = 'local';
-        break;
 
-      case 'eagle-dev.pathfinder.gov.bc.ca':
-        // prod
-        this.apiPath = 'https://eagle-dev.pathfinder.gov.bc.ca/api/public';
-        this.adminUrl = 'https://eagle-dev.pathfinder.gov.bc.ca/admin/';
-        this.env = 'dev';
-        break;
+    // The following items are loaded by a file that is only present on cluster builds.
+    // Locally, this will be empty and local defaults will be used.
+    const remote_api_path = window.localStorage.getItem('remote_api_path');
+    const remote_admin_path = window.localStorage.getItem('remote_admin_path');
+    const deployment_env = window.localStorage.getItem('deployment_env');
 
-      case 'www.test.projects.eao.gov.bc.ca':
-      case 'eagle-test.pathfinder.gov.bc.ca':
-      case 'test.projects.eao.gov.bc.ca':
-        // Test
-        this.apiPath = 'https://eagle-test.pathfinder.gov.bc.ca/api/public';
-        this.adminUrl = 'https://test.projects.eao.gov.bc.ca/admin/';
-        this.env = 'test';
-        break;
-
-      case 'eagle-test-demo.pathfinder.gov.bc.ca/':
-        // Demo
-        this.apiPath = 'https://eagle-test-demo.pathfinder.gov.bc.ca/api/public';
-        this.adminUrl = 'https://eagle-test-demo.pathfinder.gov.bc.ca/admin/';
-        this.env = 'demo';
-        break;
-
-      case 'www.projects.eao.gov.bc.ca':
-      case 'eagle-prod.pathfinder.gov.bc.ca':
-      case 'projects.eao.gov.bc.ca':
-        // prod
-        this.apiPath = 'https://eagle-prod.pathfinder.gov.bc.ca/api/public';
-        this.adminUrl = 'https://projects.eao.gov.bc.ca/admin/';
-        this.env = 'prod';
-        break;
-
-      default:
-        // Prod
-        this.apiPath = 'https://eagle-test.pathfinder.gov.bc.ca/api/public';
-        this.adminUrl = 'https://test.projects.eao.gov.bc.ca/admin/';
-        this.env = 'test';
-    };
+    this.apiPath = (_.isEmpty(remote_api_path)) ? 'http://localhost:3000/api/public' : remote_api_path;
+    this.adminUrl = (_.isEmpty(remote_admin_path)) ? 'http://localhost:4200' : remote_admin_path;
+    this.env = (_.isEmpty(deployment_env)) ? 'local' : deployment_env;
   }
 
   handleError(error: any): Observable<any> {

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -38,9 +38,9 @@ export class ApiService {
 
     // The following items are loaded by a file that is only present on cluster builds.
     // Locally, this will be empty and local defaults will be used.
-    const remote_api_path = window.localStorage.getItem('on_public_server--remote_api_path');
-    const remote_admin_path = window.localStorage.getItem('on_public_server--remote_admin_path');
-    const deployment_env = window.localStorage.getItem('on_public_server--deployment_env');
+    const remote_api_path = window.localStorage.getItem('from_public_server--remote_api_path');
+    const remote_admin_path = window.localStorage.getItem('from_public_server--remote_admin_path');
+    const deployment_env = window.localStorage.getItem('from_public_server--deployment_env');
 
     this.apiPath = (_.isEmpty(remote_api_path)) ? 'http://localhost:3000/api/public' : remote_api_path;
     this.adminUrl = (_.isEmpty(remote_admin_path)) ? 'http://localhost:4200' : remote_admin_path;

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -38,9 +38,9 @@ export class ApiService {
 
     // The following items are loaded by a file that is only present on cluster builds.
     // Locally, this will be empty and local defaults will be used.
-    const remote_api_path = window.localStorage.getItem('remote_api_path');
-    const remote_admin_path = window.localStorage.getItem('remote_admin_path');
-    const deployment_env = window.localStorage.getItem('deployment_env');
+    const remote_api_path = window.localStorage.getItem('on_public_server--remote_api_path');
+    const remote_admin_path = window.localStorage.getItem('on_public_server--remote_admin_path');
+    const deployment_env = window.localStorage.getItem('on_public_server--deployment_env');
 
     this.apiPath = (_.isEmpty(remote_api_path)) ? 'http://localhost:3000/api/public' : remote_api_path;
     this.adminUrl = (_.isEmpty(remote_admin_path)) ? 'http://localhost:4200' : remote_admin_path;

--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
 				h = d.documentElement, t = setTimeout(function () { h.className = h.className.replace(/\bwf-loading\b/g, "") + " wf-inactive"; }, config.scriptTimeout), tk = d.createElement("script"), f = false, s = d.getElementsByTagName("script")[0], a; h.className += " wf-loading"; tk.src = 'https://use.typekit.net/' + config.kitId + '.js'; tk.async = true; tk.onload = tk.onreadystatechange = function () { a = this.readyState; if (f || a && a != "complete" && a != "loaded") return; f = true; clearTimeout(t); try { Typekit.load(config) } catch (e) { } }; s.parentNode.insertBefore(tk, s)
 		})(document);
 	</script>
-	<script src="./serverEnvironmentSettings.js"></script> <!-- Generated at cluster s2i build time by the run file in the nginx-runtime -->
+	<script src="./publicServerEnvironmentSettings.js"></script> <!-- Generated at cluster s2i build time by the run file in the nginx-runtime -->
 </head>
 
 <body id="top">

--- a/src/index.html
+++ b/src/index.html
@@ -58,6 +58,7 @@
 				h = d.documentElement, t = setTimeout(function () { h.className = h.className.replace(/\bwf-loading\b/g, "") + " wf-inactive"; }, config.scriptTimeout), tk = d.createElement("script"), f = false, s = d.getElementsByTagName("script")[0], a; h.className += " wf-loading"; tk.src = 'https://use.typekit.net/' + config.kitId + '.js'; tk.async = true; tk.onload = tk.onreadystatechange = function () { a = this.readyState; if (f || a && a != "complete" && a != "loaded") return; f = true; clearTimeout(t); try { Typekit.load(config) } catch (e) { } }; s.parentNode.insertBefore(tk, s)
 		})(document);
 	</script>
+    <script src="./serverEnvironmentSettings.js"></script> <!-- Generated at cluster s2i build time by the run file in the nginx-runtime -->
 </head>
 
 <body id="top">

--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
 				h = d.documentElement, t = setTimeout(function () { h.className = h.className.replace(/\bwf-loading\b/g, "") + " wf-inactive"; }, config.scriptTimeout), tk = d.createElement("script"), f = false, s = d.getElementsByTagName("script")[0], a; h.className += " wf-loading"; tk.src = 'https://use.typekit.net/' + config.kitId + '.js'; tk.async = true; tk.onload = tk.onreadystatechange = function () { a = this.readyState; if (f || a && a != "complete" && a != "loaded") return; f = true; clearTimeout(t); try { Typekit.load(config) } catch (e) { } }; s.parentNode.insertBefore(tk, s)
 		})(document);
 	</script>
-    <script src="./serverEnvironmentSettings.js"></script> <!-- Generated at cluster s2i build time by the run file in the nginx-runtime -->
+	<script src="./serverEnvironmentSettings.js"></script> <!-- Generated at cluster s2i build time by the run file in the nginx-runtime -->
 </head>
 
 <body id="top">


### PR DESCRIPTION
This change is part of a 4 part changeset:

https://github.com/bcgov/eagle-helper-pods/pull/25
https://github.com/bcgov/eagle-admin/pull/330
https://github.com/bcgov/eagle-public/pull/179
https://github.com/bcgov/eagle-api/pull/284


Removal of hardcoded routes in Angular app and replacement with OpenShift environment variables.

Tested by doing clean deployment of API, Public and Admin.  A fresh prod db backup was edited using a local development instance of Admin to have a project name edited to have extra text "Resources As Settings" appended to its name in order to prove that we are looking at the correct database.

![Screen Shot 2019-11-20 at 12 42 05 AM](https://user-images.githubusercontent.com/37681273/69227154-3d220280-0b36-11ea-8a7b-741082dca933.png)
 