### PR TITLE
EE-721 - Project List in epic public should initially sort alphabetically 

### DIFF
--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -159,6 +159,9 @@ export class ProjectListComponent implements OnInit, OnDestroy {
 
           this.setFiltersFromParams(params);
 
+          //default sort for project list is alphabetical
+          params.sortBy = '+name'
+
           this.updateCounts();
 
           this.tableParams = this.tableTemplateUtils.getParamsFromUrl(


### PR DESCRIPTION
Change to public side so project lists sorts alphabetically. Change to sort by does not effect re-ordering.