### PR TITLE
Update map search to reduce clicks in EPIC public

### DIFF
--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -60,7 +60,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
           currentPage,
           pageSize,
           sortBy,
-          { },
+          { documentSource: 'PROJECT', datePostedStart: datePostedStart, datePostedEnd: datePostedEnd },
           true,
           null,
           this.filterForAPI,
@@ -99,8 +99,5 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     this.paramsToCollectionFilter(params, 'milestone', this.milestones, '_id');
     this.paramsToCollectionFilter(params, 'documentAuthorType', this.authors, '_id');
     this.paramsToCollectionFilter(params, 'type', this.types, '_id');
-
-    this.paramsToDateFilter(params, 'datePostedStart');
-    this.paramsToDateFilter(params, 'datePostedEnd');
   }
 }

--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -25,6 +25,8 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     const currentPage = route.params.currentPage ? route.params.currentPage : 1;
     const pageSize = route.params.pageSize ? route.params.pageSize : 10;
     const sortBy = route.params.sortBy && route.params.sortBy !== 'null' ? route.params.sortBy : '-datePosted';
+    const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : '0001-01-01';
+    const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : '9999-12-31';
     const keywords = route.params.keywords;
 
     // Get the lists first
@@ -58,7 +60,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
           currentPage,
           pageSize,
           sortBy,
-          { documentSource: 'PROJECT', eaoStatus: 'Published' },
+          { },
           true,
           null,
           this.filterForAPI,

--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -58,7 +58,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
           currentPage,
           pageSize,
           sortBy,
-          { documentSource: 'PROJECT' },
+          { documentSource: 'PROJECT', eaoStatus: 'Published' },
           true,
           null,
           this.filterForAPI,

--- a/src/app/project/project-details-tab/project-details-tab.component.ts
+++ b/src/app/project/project-details-tab/project-details-tab.component.ts
@@ -157,9 +157,12 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
   // ref: https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
   private fixMap() {
     if (this.elementRef.nativeElement.offsetParent) {
-      let markerBounds = L.latLngBounds([L.latLng(this.project.centroid[1], this.project.centroid[0])]);
-      this.map.fitBounds(markerBounds);
-      this.map.setZoom(5);
+      this.fitBounds(this.appFG.getBounds());
+
+      // option to centre the map instead of prov view
+      // let markerBounds = L.latLngBounds([L.latLng(this.project.centroid[1], this.project.centroid[0])]);
+      // this.map.fitBounds(markerBounds);
+      // this.map.setZoom(5);
 
     } else {
       setTimeout(this.fixMap.bind(this), 50);
@@ -172,7 +175,7 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
       // ref: https://github.com/Leaflet/Leaflet/issues/3249
       animate: false,
       // use bottom padding to keep shape in bounds
-     // paddingBottomRight: [0, 35]
+      paddingBottomRight: [0, 35]
     };
 
     if (bounds && bounds.isValid()) {

--- a/src/app/project/project-details-tab/project-details-tab.component.ts
+++ b/src/app/project/project-details-tab/project-details-tab.component.ts
@@ -76,6 +76,11 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
       maxZoom: 16,
       noWrap: true
     });
+    const OpenMapSurfer_Roads = L.tileLayer('https://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}', {
+      attribution: 'Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @ University of Heidelberg</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      maxZoom: 20,
+      noWrap: true
+    });
     const World_Topo_Map = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', {
       attribution: 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community',
       maxZoom: 16,
@@ -109,6 +114,7 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
     const baseLayers = {
       'Ocean Base': Esri_OceanBasemap,
       'Nat Geo World Map': Esri_NatGeoWorldMap,
+      'Open Surfer Roads': OpenMapSurfer_Roads,
       'World Topographic': World_Topo_Map,
       'World Imagery': World_Imagery
     };
@@ -157,12 +163,11 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
   // ref: https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
   private fixMap() {
     if (this.elementRef.nativeElement.offsetParent) {
-      this.fitBounds(this.appFG.getBounds());
+      //this.fitBounds(this.appFG.getBounds());
 
-      // option to centre the map instead of prov view
-      // let markerBounds = L.latLngBounds([L.latLng(this.project.centroid[1], this.project.centroid[0])]);
-      // this.map.fitBounds(markerBounds);
-      // this.map.setZoom(5);
+      let markerBounds = L.latLngBounds([L.latLng(this.project.centroid[1], this.project.centroid[0])]);
+      this.map.fitBounds(markerBounds);
+      this.map.setZoom(5);
 
     } else {
       setTimeout(this.fixMap.bind(this), 50);

--- a/src/app/project/project-details-tab/project-details-tab.component.ts
+++ b/src/app/project/project-details-tab/project-details-tab.component.ts
@@ -76,11 +76,6 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
       maxZoom: 16,
       noWrap: true
     });
-    const OpenMapSurfer_Roads = L.tileLayer('https://korona.geog.uni-heidelberg.de/tiles/roads/x={x}&y={y}&z={z}', {
-      attribution: 'Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @ University of Heidelberg</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-      maxZoom: 20,
-      noWrap: true
-    });
     const World_Topo_Map = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}', {
       attribution: 'Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community',
       maxZoom: 16,
@@ -114,7 +109,6 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
     const baseLayers = {
       'Ocean Base': Esri_OceanBasemap,
       'Nat Geo World Map': Esri_NatGeoWorldMap,
-      'Open Surfer Roads': OpenMapSurfer_Roads,
       'World Topographic': World_Topo_Map,
       'World Imagery': World_Imagery
     };
@@ -163,8 +157,6 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
   // ref: https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
   private fixMap() {
     if (this.elementRef.nativeElement.offsetParent) {
-      //this.fitBounds(this.appFG.getBounds());
-
       let markerBounds = L.latLngBounds([L.latLng(this.project.centroid[1], this.project.centroid[0])]);
       this.map.fitBounds(markerBounds);
       this.map.setZoom(5);
@@ -180,7 +172,7 @@ export class ProjectDetailsTabComponent implements OnInit, AfterViewInit, OnDest
       // ref: https://github.com/Leaflet/Leaflet/issues/3249
       animate: false,
       // use bottom padding to keep shape in bounds
-      paddingBottomRight: [0, 35]
+     // paddingBottomRight: [0, 35]
     };
 
     if (bounds && bounds.isValid()) {

--- a/src/app/projects/projlist-filters/projlist-filters.component.html
+++ b/src/app/projects/projlist-filters/projlist-filters.component.html
@@ -1,6 +1,6 @@
 <div class="app-filters__container d-flex flex-column" name="Filters to limit displayed EAO Projects">
   <div class="search-container" id="applist-filters">
-    <fieldset class="additional-filters" (click)="$event.stopPropagation()">
+    <fieldset class="additional-filters" (click)="$event.stopPropagation(); applyAllFilters();">
       <div class="form-group typeahead-container">
         <label for="applicantInput">Search Environmental Assessment Projects</label>
         <input type="text" class="form-control gtm-filter-applicant " placeholder="Start Typing A Project Name" id="applicantInput"

--- a/src/app/projects/projlist-map/projlist-map.component.ts
+++ b/src/app/projects/projlist-map/projlist-map.component.ts
@@ -271,6 +271,19 @@ export class ProjlistMapComponent implements AfterViewInit, OnChanges, OnDestroy
         const markerLatLng = marker.getLatLng();
         // app is visible if map contains its marker
         app.isVisible = mapBounds.contains(markerLatLng);
+
+        // If there is only one result from the filter
+        // force the popup to auto-display
+        if (this.markerList.length === 1 && app.isVisible) {
+          if (marker.getPopup()) {
+            marker.openPopup();
+          } else {
+            // create the popup
+            this.createMarkerPopup(app, marker);
+            marker.openPopup();
+          }
+        }
+
       }
     }
 
@@ -336,6 +349,10 @@ export class ProjlistMapComponent implements AfterViewInit, OnChanges, OnDestroy
     const app = args[0] as Project;
     const marker = args[1].target as L.Marker;
 
+    this.createMarkerPopup(app, marker);
+  }
+
+  private createMarkerPopup(app: Project, marker: L.Marker) {
     this.applist.toggleCurrentApp(app); // update selected item in app list
 
     // if there's already a popup, delete it

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -134,9 +134,14 @@ export class ApiService {
       });
     }
     if (filter !== {}) {
-      Object.keys(filter).forEach(key => {
-        filter[key].split(',').forEach(item => {
-          let safeItem = this.utils.encodeString(item, true);
+      let safeItem;
+      Object.keys(filter).map(key => {
+        filter[key].split(',').map(item => {
+          if (item.includes('&')) {
+            safeItem = this.utils.encodeString(item, true);
+          } else {
+            safeItem = item;
+          }
           queryString += `&or[${key}]=${safeItem}`;
         });
       });


### PR DESCRIPTION
Changes for ticket EE-169.

When you click on a project in the search drop down menu, the project pin and pop-up information box automatically open if there is only one result. Filtering happens automatically on the map so you don't have to click "search" if you select a single option
