### PR TITLE
Missed paging for EE-812

### DIFF
--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -25,8 +25,8 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     const currentPage = route.params.currentPage ? route.params.currentPage : 1;
     const pageSize = route.params.pageSize ? route.params.pageSize : 10;
     const sortBy = route.params.sortBy && route.params.sortBy !== 'null' ? route.params.sortBy : '-datePosted';
-    const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : '0001-01-01';
-    const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : '9999-12-31';
+    const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : null;
+    const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : null;
     const keywords = route.params.keywords;
 
     // Get the lists first

--- a/src/app/project/documents/documents-tab.component.ts
+++ b/src/app/project/documents/documents-tab.component.ts
@@ -450,8 +450,15 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
     const params = this.terms.getParams();
     this.setParamsFromFilters(params);
 
-    const datePostedStart = params.hasOwnProperty('datePostedStart') && params.datePostedStart ? params.datePostedStart : '0001-01-01';
-    const datePostedEnd = params.hasOwnProperty('datePostedEnd') && params.datePostedEnd ? params.datePostedEnd : '9999-12-31';
+    const datePostedStart = params.hasOwnProperty('datePostedStart') && params.datePostedStart ? params.datePostedStart : null;
+    const datePostedEnd = params.hasOwnProperty('datePostedEnd') && params.datePostedEnd ? params.datePostedEnd : null;
+
+    let queryModifiers = { documentSource: 'PROJECT' };
+
+    if (datePostedStart !== null && datePostedEnd !== null) {
+      queryModifiers['datePostedStart'] = datePostedStart;
+      queryModifiers['datePostedEnd'] = datePostedEnd;
+    }
 
     this.searchService.getSearchResults(
       this.tableParams.keywords,
@@ -460,7 +467,7 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
       pageNumber,
       this.tableParams.pageSize,
       this.tableParams.sortBy,
-      { documentSource: 'PROJECT', datePostedStart: datePostedStart, datePostedEnd: datePostedEnd },
+      queryModifiers,
       true,
       null,
       this.filterForAPI,


### PR DESCRIPTION
Additional fix for EE-812 to ensure document counts match between admin and public. Document counts match on initial query, but paged queries were supplying invalid dates.