### PR TITLE
Re-implementing OR for query values

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -142,7 +142,7 @@ export class ApiService {
           } else {
             safeItem = item;
           }
-          queryString += `&and[${key}]=${safeItem}`;
+          queryString += `&or[${key}]=${safeItem}`;
         });
       });
     }


### PR DESCRIPTION
"or" setting on query modifiers was removed and replaced with the original "and", reverting back to "or"

Has a dependency on [API PR 391](https://github.com/bcgov/eagle-api/pull/391)