### PR TITLE
Comment Period Final Day label

### DIFF
--- a/src/app/models/commentperiod.ts
+++ b/src/app/models/commentperiod.ts
@@ -114,7 +114,7 @@ export class CommentPeriod {
       if (moment(now).isBetween(dateStarted, dateCompleted)) {
         this.commentPeriodStatus = 'Open';
         let days = dateCompleted.diff(moment(now), 'days');
-        this.daysRemaining = days + (days === 1 ? ' Day ' : ' Days ') + 'Remaining';
+        this.daysRemaining = days === 0 ? 'Final Day' : days + (days === 1 ? ' Day ' : ' Days ') + 'Remaining';
       } else if (moment(now).isAfter(dateCompleted)) {
         this.commentPeriodStatus = 'Closed';
         this.daysRemaining = 'Completed';

--- a/src/app/services/commentperiod.service.ts
+++ b/src/app/services/commentperiod.service.ts
@@ -79,7 +79,7 @@ export class CommentPeriodService {
     }
 
     const now = new Date();
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 0, 0);
 
     if (commentPeriod.dateCompleted < today) {
       return this.CLOSED;


### PR DESCRIPTION
See ticket [EE-830](https://bcmines.atlassian.net/browse/EE-830)

Adding label to display 'Final Day' instead of '0 Days Remaining'.
Added time to date check on PCP status so comment periods created the day they start aren't set as 'Not Started'