### PR TITLE
Storing filters on session

### DIFF
--- a/src/app/project/documents/documents-tab.component.ts
+++ b/src/app/project/documents/documents-tab.component.ts
@@ -159,12 +159,26 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
             this.projectPhases = _.sortBy(this.projectPhases, ['legislation']);
           }
 
+          this.currentProject = this.storageService.state.currentProject.data;
+
+          if (this.currentProject && this.storageService.state[this.currentProject._id]) {
+            if (this.storageService.state[this.currentProject._id].filterForUI) {
+              this.filterForUI = this.storageService.state[this.currentProject._id].filterForUI;
+              this.setParamsFromFilters(params);
+            }
+
+            if (this.storageService.state[this.currentProject._id].tableParams) {
+              this.tableParams = this.storageService.state[this.currentProject._id].tableParams;
+            }
+          }
+
+          if (!this.tableParams) {
+            this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, this.filterForURL);
+          }
+
           this.setFiltersFromParams(params);
 
           this.updateCounts();
-
-          this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, this.filterForURL);
-
 
           if (res.documents && res.documents[0].data.meta && res.documents[0].data.meta.length > 0) {
             this.tableParams.totalListItems = res.documents[0].data.meta[0].searchResultsTotal;
@@ -188,6 +202,10 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
 
     this.currentProject = this.storageService.state.currentProject.data;
 
+    if (!this.storageService.state[this.currentProject._id]) {
+      this.storageService.state[this.currentProject._id] = {};
+    }
+
     this.searchService.getSearchResults(
       '',
       'Document',
@@ -195,9 +213,9 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
         { name: 'project', value: this.currentProject._id },
         { name: 'categorized', value: false }
       ],
-      1,
-      10,
-      '-datePosted',
+      this.storageService.state[this.currentProject._id].tableParams ? this.storageService.state[this.currentProject._id].tableParams.currentPage : 1,
+      this.storageService.state[this.currentProject._id].tableParams ? this.storageService.state[this.currentProject._id].tableParams.pageSize : 10,
+      this.storageService.state[this.currentProject._id].tableParams ? this.storageService.state[this.currentProject._id].tableParams.sortBy : '-datePosted',
       { documentSource: 'PROJECT' },
       true,
       null,
@@ -364,6 +382,7 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
     if (this.filterForUI[name].length) {
       const values = this.filterForUI[name].map(record => { return record[identifyBy]; });
       params[name] = values.join(',');
+      this.storageService.state[this.currentProject._id].filterForAPI[name] = values.join(',');
     }
   }
 
@@ -466,6 +485,10 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
       queryModifiers['datePostedEnd'] = datePostedEnd;
     }
 
+    if (this.storageService) {
+      this.storageService.state[this.currentProject._id].tableParams = this.tableParams;
+    }
+
     this.searchService.getSearchResults(
       this.tableParams.keywords,
       'Document',
@@ -522,7 +545,14 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
     params['keywords'] = this.tableParams.keywords;
     params['pageSize'] = this.tableParams.pageSize;
 
+    if (this.storageService) {
+      this.storageService.state[this.currentProject._id].tableParams = this.tableParams;
+      this.storageService.state[this.currentProject._id].filterForUI = this.filterForUI;
+      this.storageService.state[this.currentProject._id].filterForAPI = {};
+    }
+
     this.setParamsFromFilters(params);
+
 
     this.router.navigate(['p', this.currentProject._id, 'documents', params]);
   }

--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -178,6 +178,16 @@ export class ProjectListComponent implements OnInit, OnDestroy {
           this.tableParams.sortBy = '+name';
         }
 
+        // check if the filters are in session state, for handling
+        // retaining the filters when a user clicks back from a project
+        // into the project list
+        if (this.storageService && this.storageService.state.projList) {
+          this.filterForAPI = this.storageService.state.projList.filterForAPI;
+          this.filterForUI = this.storageService.state.projList.filterForUI;
+          this.tableParams = this.storageService.state.projList.tableParams;
+          this.setParamsFromFilters(params);
+        }
+
         if (this.filterForAPI.hasOwnProperty('projectPhase')) {
           this.filterForAPI['currentPhaseName'] = this.filterForAPI['projectPhase'];
           delete this.filterForAPI['projectPhase'];
@@ -216,6 +226,17 @@ export class ProjectListComponent implements OnInit, OnDestroy {
             this.projects = [];
           }
           this.setRowData();
+
+          // store the state of the filterForAPI set into the session
+          // so a user can navigate back to this page without losing
+          // their filters
+          if (this.storageService) {
+            this.storageService.state.projList = {};
+            this.storageService.state.projList.filterForAPI = this.filterForAPI;
+            this.storageService.state.projList.filterForUI = this.filterForUI;
+            this.storageService.state.projList.tableParams = this.tableParams;
+          }
+
         } else {
           alert('Uh-oh, couldn\'t load search results');
           // results not found --> navigate back to search
@@ -466,6 +487,9 @@ export class ProjectListComponent implements OnInit, OnDestroy {
       pageNumber,
       this.tableParams.sortBy
     );
+
+    // store the table params in the event of a page navigation
+    this.storageService.state.projList.tableParams = this.tableParams;
 
     if (this.filterForAPI.hasOwnProperty('projectPhase')) {
       this.filterForAPI['currentPhaseName'] = this.filterForAPI['projectPhase'];


### PR DESCRIPTION
Enabling storing filters and table page information on the storage service for public project list and project document lists. Changing pages will retain previous search information.

See ticket [EE-778](https://bcmines.atlassian.net/browse/EE-778)