### PR TITLE
Display Current Comment Period Over Closed

### DIFF
--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -88,10 +88,22 @@ export class ProjectService {
     return this.api.getProject(projId, cpStart, cpEnd)
       .map((projects: Project[]) => {
         // get upcoming comment period if there is one and convert it into a comment period object.
+        // If there are multiple comment periods any that is currently running is a higher priority than a past comment period
         if (projects) {
-
-          if (projects[0].commentPeriodForBanner && projects[0].commentPeriodForBanner.length > 0) {
+          if (projects[0].commentPeriodForBanner && projects[0].commentPeriodForBanner.length === 1) {
             projects[0].commentPeriodForBanner = new CommentPeriod(projects[0].commentPeriodForBanner[0]);
+          } else if (projects[0].commentPeriodForBanner && projects[0].commentPeriodForBanner.length > 1) {
+              let now = new Date
+              let currentDate = now.toISOString();
+              // Default to the same comment period we're using currently in case one is not active
+              let finalCommentPeriod = new CommentPeriod(projects[0].commentPeriodForBanner[0]);
+              for ( let commentPeriod in projects[0].commentPeriodForBanner){
+                if (Date.parse(projects[0].commentPeriodForBanner[commentPeriod].dateCompleted) > Date.parse(currentDate)
+                && Date.parse(projects[0].commentPeriodForBanner[commentPeriod].dateStarted)  < Date.parse(currentDate) ) {
+                    finalCommentPeriod = new CommentPeriod(projects[0].commentPeriodForBanner[commentPeriod]);
+                }
+              }
+              projects[0].commentPeriodForBanner = finalCommentPeriod
           } else {
             projects[0].commentPeriodForBanner = null;
           }

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -90,9 +90,9 @@ export class ProjectService {
         // get upcoming comment period if there is one and convert it into a comment period object.
         // If there are multiple comment periods any that is currently running is a higher priority than a past comment period
         if (projects) {
-          if (projects[0].commentPeriodForBanner && projects[0].commentPeriodForBanner.length === 1) {
+          if (projects[0] && projects[0].commentPeriodForBanner && projects[0].commentPeriodForBanner.length === 1) {
             projects[0].commentPeriodForBanner = new CommentPeriod(projects[0].commentPeriodForBanner[0]);
-          } else if (projects[0].commentPeriodForBanner && projects[0].commentPeriodForBanner.length > 1) {
+          } else if (projects[0] && projects[0].commentPeriodForBanner && projects[0].commentPeriodForBanner.length > 1) {
               let now = new Date
               let currentDate = now.toISOString();
               // Default to the same comment period we're using currently in case one is not active


### PR DESCRIPTION
Sets the public comment period banner to stop display the comment period that is closed but only if a current comment period is available.
Ticket: https://bcmines.atlassian.net/browse/EE-860