### PR TITLE
Moving pcp file list below comment

### DIFF
--- a/src/app/project/comments/comments-table-rows/comments-table-rows.component.html
+++ b/src/app/project/comments/comments-table-rows/comments-table-rows.component.html
@@ -20,15 +20,6 @@
         {{(comment.dateAdded | date:'longDate') || "-"}}
       </div>
     </div>
-    <div class="pb-3" *ngIf="comment.documents.length > 0">
-      <div class="attachment" *ngFor="let file of comment.documents" (click)="openAttachment(file)">
-        <div *ngIf="file && file.internalOriginalName">
-          <i class="material-icons">
-            attach_file
-          </i>{{file.internalOriginalName}}
-        </div>
-      </div>
-    </div>
     <div>
       <div *ngIf="comment.comment && comment.comment.length > 120">
         <p *ngIf="comment.comment && comment.expanded == true">
@@ -40,6 +31,15 @@
         <button class="clickable" (click)="toggle(comment)">{{comment.buttonName}}</button>
       </div>
       <p *ngIf="comment.comment && comment.comment.length <= 120">{{comment.comment}}</p>
+    </div>
+    <div class="pb-3" *ngIf="comment.documents.length > 0">
+        <div class="attachment" *ngFor="let file of comment.documents" (click)="openAttachment(file)">
+            <div *ngIf="file && file.internalOriginalName">
+            <i class="material-icons">
+                attach_file
+            </i>{{file.internalOriginalName}}
+            </div>
+        </div>
     </div>
   </td>
 </tr>

--- a/src/app/project/documents/project-document-table-rows/project-document-table-rows.component.ts
+++ b/src/app/project/documents/project-document-table-rows/project-document-table-rows.component.ts
@@ -91,7 +91,7 @@ export class DocumentTableRowsComponent implements OnInit, OnDestroy, TableCompo
     } catch (e) {
       console.log('error:', e);
     }
-    window.open('/api/document/' + item._id + '/fetch/' + safeName, '_blank');
+    window.open('/api/public/document/' + item._id + '/download/' + safeName, '_blank');
   }
   ngOnDestroy() {
     this.ngUnsubscribe.next();

--- a/src/app/project/pins/pins-table-rows/pins-table-rows.component.ts
+++ b/src/app/project/pins/pins-table-rows/pins-table-rows.component.ts
@@ -50,6 +50,6 @@ export class PinsTableRowsComponent implements OnInit, TableComponent {
     // } catch (e) {
     //   console.log('error:', e);
     // }
-    // window.open('/api/document/' + item._id + '/fetch/' + safeName, '_blank');
+    // window.open('/api/public/document/' + item._id + '/download/' + safeName, '_blank');
   }
 }

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -100,7 +100,7 @@ export class ApiService {
       console.log('error', e);
     }
     console.log('safeName', safeName);
-    window.open('/api/document/' + document._id + '/fetch/' + safeName, '_blank');
+    window.open('/api/public/document/' + document._id + '/download/' + safeName, '_blank');
   }
 
   private downloadResource(id: string): Promise<Blob> {


### PR DESCRIPTION
Attachments for any given comment are placed above the comment text, when they should more logically be viewed below the comment text.

See ticket [EE-229](https://bcmines.atlassian.net/browse/EE-229)