### PR TITLE
Add sort orders on public to be sent to API

### DIFF
--- a/src/app/project/certificates/application-resolver.service.ts
+++ b/src/app/project/certificates/application-resolver.service.ts
@@ -19,7 +19,7 @@ export class ApplicationResolver implements Resolve<Observable<object>> {
     const projectId = route.parent.paramMap.get('projId');
     const currentPage = route.params.currentPage ? route.params.currentPage : 1;
     const pageSize = route.params.pageSize ? route.params.pageSize : 10;
-    const sortBy = route.params.sortBy && route.params.sortBy !== 'null' ? route.params.sortBy : '-datePosted';
+    const sortBy = route.params.sortBy && route.params.sortBy !== 'null' ? route.params.sortBy : '+sortOrder,-datePosted,+displayName';
     const keywords = route.params.keywords;
 
     return this.configService.lists.switchMap (list => {

--- a/src/app/project/certificates/certificates.component.ts
+++ b/src/app/project/certificates/certificates.component.ts
@@ -66,6 +66,8 @@ export class CertificatesComponent implements OnInit, OnDestroy {
       .subscribe(params => {
         if (this.currentUrl === 'amendments') {
           this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params);
+        } else if(this.currentUrl === 'application'){
+          this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, null, '+sortOrder,-datePosted,+displayName');
         } else {
           // Different sort order:
           this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, null, '+displayName');

--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -27,7 +27,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     const projectId = route.parent.paramMap.get('projId');
     let currentPage = route.params.currentPage ? route.params.currentPage : 1;
     let pageSize = route.params.pageSize ? route.params.pageSize : 10;
-    let sortBy = route.params.sortBy && route.params.sortBy !== 'null' ? route.params.sortBy : '-datePosted';
+    let sortBy = route.params.sortBy && route.params.sortBy !== 'null' ? route.params.sortBy : '-datePosted,+displayName';
     const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : null;
     const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : null;
     const keywords = route.params.hasOwnProperty('keywords') ? route.params.keywords : '';


### PR DESCRIPTION
https://bcmines.atlassian.net/browse/EE-808

Sort order to allow the application tab to sort in multiple ways. Reworking of the API here: https://github.com/bcgov/eagle-api/pull/425
Led to refactoring a section of the code that has the twoSorts section of the search aggregation.