### PR TITLE
NOBUG: Fix karma config and test runner

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,8 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/0.13/config/configuration-file.html
 
+process.env.CHROME_BIN = require('puppeteer').executablePath()
+
 module.exports = function (config) {
   config.set({
     basePath: '',
@@ -41,8 +43,30 @@ module.exports = function (config) {
         ChromeHeadlessNoSandbox: {
             base: 'ChromeHeadless',
             flags: [
-              '--no-sandbox',
-              '--v=1',
+              '--no-sandbox', // required to run without privileges in docker
+              '--user-data-dir=/tmp/chrome-test-profile',
+              '--disable-web-security',
+              '--disable-gpu',
+              '--disable-background-networking',
+              '--disable-default-apps',
+              '--disable-extensions',
+              '--disable-sync',
+              '--disable-translate',
+              '--headless',
+              '--hide-scrollbars',
+              '--metrics-recording-only',
+              '--mute-audio',
+              '--no-first-run',
+              '--safebrowsing-disable-auto-update',
+              '--ignore-certificate-errors',
+              '--ignore-ssl-errors',
+              '--ignore-certificate-errors-spki-list',
+              '--remote-debugging-port=9222',
+              '--remote-debugging-address=0.0.0.0',
+              '--disable-dev-shm-usage',
+              '--disable-setuid-sandbox',
+              '--disable-namespace-sandbox',
+              '--window-size=800x600',
               '--disable-background-timer-throttling',
               '--disable-renderer-backgrounding'
             ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "ng build --prod --configuration=production",
     "pretest": "",
     "test": "echo 'Test suite should be run with \"`npm run tests` or npm `run tests-ci`\"'",
-    "tests": "ng test",
+    "tests": "ng test --watch=false",
     "tests-ci": "ng test --watch=false",
     "lint": "ng lint --format=stylish",
     "e2e": "ng e2e"
@@ -83,6 +83,7 @@
     "node": "^8.16.0",
     "pre-push": "^0.1.1",
     "protractor": "~5.4.3",
+    "puppeteer": "^2.1.1",
     "ts-node": "2.0.0",
     "tslint": "^5.19.0",
     "typescript": "^2.9.2"


### PR DESCRIPTION
This makes some optimizations to karma/chrome headless, and the npm run tests command.  Now this will drop to a shell after running `npm run tests`, since watching it wont.