### PR TITLE
Added check to keep default params on no search params

### DIFF
--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -27,7 +27,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     const projectId = route.parent.paramMap.get('projId');
     let currentPage = route.params.currentPage ? route.params.currentPage : 1;
     let pageSize = route.params.pageSize ? route.params.pageSize : 10;
-    let sortBy = route.params.sortBy && route.params.sortBy !== 'null'|| '' ? route.params.sortBy : '-datePosted,+displayName';
+    let sortBy = route.params.sortBy && route.params.sortBy !== 'null' || '' ? route.params.sortBy : '-datePosted,+displayName';
     const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : null;
     const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : null;
     const keywords = route.params.hasOwnProperty('keywords') ? route.params.keywords : '';

--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -27,7 +27,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     const projectId = route.parent.paramMap.get('projId');
     let currentPage = route.params.currentPage ? route.params.currentPage : 1;
     let pageSize = route.params.pageSize ? route.params.pageSize : 10;
-    let sortBy = route.params.sortBy && route.params.sortBy !== 'null' ? route.params.sortBy : '-datePosted,+displayName';
+    let sortBy = route.params.sortBy && route.params.sortBy !== 'null'|| '' ? route.params.sortBy : '-datePosted,+displayName';
     const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : null;
     const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : null;
     const keywords = route.params.hasOwnProperty('keywords') ? route.params.keywords : '';

--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -27,7 +27,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     const projectId = route.parent.paramMap.get('projId');
     let currentPage = route.params.currentPage ? route.params.currentPage : 1;
     let pageSize = route.params.pageSize ? route.params.pageSize : 10;
-    let sortBy = route.params.sortBy ? route.params.sortBy : '-datePosted,+displayName'; 
+    let sortBy = route.params.sortBy ? route.params.sortBy : '-datePosted,+displayName';
     const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : null;
     const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : null;
     const keywords = route.params.hasOwnProperty('keywords') ? route.params.keywords : '';
@@ -73,7 +73,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
           if (tableParams) {
             currentPage = tableParams.currentPage;
             pageSize = tableParams.pageSize;
-            sortBy = tableParams.sortBy ? tableParams.sortBy: sortBy;
+            sortBy = tableParams.sortBy ? tableParams.sortBy : sortBy;
           }
 
           if (filterForUI) {

--- a/src/app/project/documents/documents-resolver.service.ts
+++ b/src/app/project/documents/documents-resolver.service.ts
@@ -27,7 +27,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
     const projectId = route.parent.paramMap.get('projId');
     let currentPage = route.params.currentPage ? route.params.currentPage : 1;
     let pageSize = route.params.pageSize ? route.params.pageSize : 10;
-    let sortBy = route.params.sortBy && route.params.sortBy !== 'null' || '' ? route.params.sortBy : '-datePosted,+displayName';
+    let sortBy = route.params.sortBy ? route.params.sortBy : '-datePosted,+displayName'; 
     const datePostedStart = route.params.hasOwnProperty('datePostedStart') &&  route.params.datePostedStart ? route.params.datePostedStart : null;
     const datePostedEnd = route.params.hasOwnProperty('datePostedEnd') && route.params.datePostedEnd ? route.params.datePostedEnd : null;
     const keywords = route.params.hasOwnProperty('keywords') ? route.params.keywords : '';
@@ -73,7 +73,7 @@ export class DocumentsResolver implements Resolve<Observable<object>> {
           if (tableParams) {
             currentPage = tableParams.currentPage;
             pageSize = tableParams.pageSize;
-            sortBy = tableParams.sortBy;
+            sortBy = tableParams.sortBy ? tableParams.sortBy: sortBy;
           }
 
           if (filterForUI) {


### PR DESCRIPTION
To keep search consistent on documents a search with no filters is considered to have the default search filters applied.

Ticket: https://bcmines.atlassian.net/browse/EE-954