### PR TITLE
Removing hard-coded sortby

### DIFF
--- a/src/app/projects/project-list/project-list.component.ts
+++ b/src/app/projects/project-list/project-list.component.ts
@@ -504,7 +504,7 @@ export class ProjectListComponent implements OnInit, OnDestroy {
     params['ms'] = new Date().getMilliseconds();
     params['dataset'] = this.terms.dataset;
     params['currentPage'] = this.tableParams.currentPage;
-    params['sortBy'] = this.tableParams.sortBy = '-score';
+    params['sortBy'] = this.tableParams.sortBy;
     params['keywords'] = this.tableParams.keywords;
     params['pageSize'] = this.tableParams.pageSize
     this.setParamsFromFilters(params);


### PR DESCRIPTION
Project list sorting was failing due to a hard-coded value in the paging functions. This just removes the unnecessary value.