### PR TITLE
parameterize resource requests and limits

### DIFF
--- a/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
+++ b/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
@@ -86,12 +86,12 @@
                 ],
                 "resources": {
                   "requests": {
-                    "cpu": "1m",
-                    "memory": "80Mi"
+                    "cpu": "${NODEJS_CPU_REQUEST}",
+                    "memory": "${NODEJS_MEMORY_REQUEST}"
                   },
                   "limits": {
-                    "cpu": "10m",
-                    "memory": "100Mi"
+                    "cpu": "${NODEJS_CPU_LIMIT}",
+                    "memory": "${NODEJS_MEMORY_LIMIT}"
                   }
                 },
                 "livenessProbe": {
@@ -265,6 +265,30 @@
       "displayName": "URL path to Admin",
       "description": "The 'https://' prefixed URL path to the Admin app that the public Angular app will link to.  Note that the trailing slash is required.",
       "value": "https://eagle-your-openshift-namespace.pathfinder.gov.bc.ca/admin/"
+    },
+    {
+      "name": "NODEJS_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Reserved amount of CPU (in cores) the Node.js container can use.",
+      "value": "1m"
+    },
+    {
+      "name": "NODEJS_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Reserved amount of memory the Node.js container can use.",
+      "value": "80Mi"
+    },
+    {
+      "name": "NODEJS_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU (in cores) the Node.js container can use.",
+      "value": "10m"
+    },
+    {
+      "name": "NODEJS_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the Node.js container can use.",
+      "value": "100Mi"
     }
   ]
 }


### PR DESCRIPTION
use environment variables for resources so they can be overridden from defaults