### PR TITLE
Adding handler for the PCP special case

### DIFF
--- a/src/app/shared/components/table-template/table-template.component.ts
+++ b/src/app/shared/components/table-template/table-template.component.ts
@@ -105,7 +105,7 @@ export class TableTemplateComponent implements OnInit, OnChanges, OnDestroy {
             this.filters.forEach(filter => {
               if (filter.id === filterName) {
                 filter.options.forEach(option => {
-                  if (option.hasOwnProperty('code') && option.name === val) {
+                  if (option.hasOwnProperty('code') && option.name.toLowerCase() === val.toLowerCase()) {
                     filter.selectedOptions.push(option);
                   } else if (option.hasOwnProperty('_id') && option._id === val) {
                     filter.selectedOptions.push(option);
@@ -261,7 +261,7 @@ export class TableTemplateComponent implements OnInit, OnChanges, OnDestroy {
       filtersForAPI[filter.id] = '';
       filter.selectedOptions.forEach(option => {
         if (option.hasOwnProperty('code')) {
-          filtersForAPI[filter.id] += option.name + ',';
+          filtersForAPI[filter.id] += filter.id === 'pcp' ? option.code : option.name + ',';
         } else if (option.hasOwnProperty('_id')) {
           filtersForAPI[filter.id] += option._id + ',';
         } else {

--- a/src/app/shared/components/table-template/table-template.component.ts
+++ b/src/app/shared/components/table-template/table-template.component.ts
@@ -261,7 +261,7 @@ export class TableTemplateComponent implements OnInit, OnChanges, OnDestroy {
       filtersForAPI[filter.id] = '';
       filter.selectedOptions.forEach(option => {
         if (option.hasOwnProperty('code')) {
-          filtersForAPI[filter.id] += filter.id === 'pcp' ? option.code : option.name + ',';
+          filtersForAPI[filter.id] += (filter.id === 'pcp' ? option.code : option.name) + ',';
         } else if (option.hasOwnProperty('_id')) {
           filtersForAPI[filter.id] += option._id + ',';
         } else {


### PR DESCRIPTION
PCP filters in API use the code, not the name. All other codes use the name. This change is to include a special case for the PCP value so we assign the correct value to the filterForAPI object.