### PR TITLE
Fix to project document table

### DIFF
--- a/src/app/project/documents/documents-tab.component.html
+++ b/src/app/project/documents/documents-tab.component.html
@@ -7,7 +7,6 @@
                             [data]="documentTableData"
                             (onColumnSort)='setColumnSort($event)'
                             (onSelectedRow)='updateSelectedRow($event)'
-                            (onPageNumUpdate)='getPaginatedDocs($event)'
                             [showSearch]="true"
                             (onSearch)='executeSearch($event)'
                             [showAdvancedSearch]="true"

--- a/src/app/project/documents/documents-tab.component.ts
+++ b/src/app/project/documents/documents-tab.component.ts
@@ -287,6 +287,7 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
 
   executeSearch(apiFilters) {
     this.terms.keywords = apiFilters.keywords;
+    this.tableParams.keywords = apiFilters.keywords;
     this.filterForAPI = apiFilters.filterForAPI;
 
     // build filterForUI/URL from the new filterForAPI object


### PR DESCRIPTION
Quick fix to the behaviour of the project documents table to correct a double-trigger due to the getPaginated calling search (when it shouldnt have), and to map keywords to terms and tableParams for persistence.

High priority to get this fix into production asap.

See ticker [EE-1049](https://bcmines.atlassian.net/browse/EE-1049)