### PR TITLE
Project Document fix, table template fix

### DIFF
--- a/src/app/project/documents/documents-tab.component.html
+++ b/src/app/project/documents/documents-tab.component.html
@@ -5,7 +5,6 @@
     <section class="tab-section" *ngIf="!loading">
         <app-table-template [columns]="documentTableColumns"
                             [data]="documentTableData"
-                            (onColumnSort)='setColumnSort($event)'
                             (onSelectedRow)='updateSelectedRow($event)'
                             [showSearch]="true"
                             (onSearch)='executeSearch($event)'

--- a/src/app/project/documents/documents-tab.component.ts
+++ b/src/app/project/documents/documents-tab.component.ts
@@ -44,7 +44,6 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
   public tableParams: TableParamsObject = new TableParamsObject();
   public terms = new SearchTerms();
 
-  public filterForURL: object = {};
   public filterForAPI: object = {};
   public filterForUI: DocumentFilterObject = new DocumentFilterObject();
 
@@ -168,7 +167,7 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
           }
 
           if (!this.tableParams) {
-            this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, this.filterForURL);
+            this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params, this.filterForAPI);
           }
 
           if (res.documents && res.documents[0].data.meta && res.documents[0].data.meta.length > 0) {
@@ -268,10 +267,6 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
     );
   }
 
-  setColumnSort() {
-    this.getPaginatedDocs(this.tableParams.currentPage);
-  }
-
   isEnabled(button) {
     switch (button) {
       case 'copyLink':
@@ -290,24 +285,14 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
     this.tableParams.keywords = apiFilters.keywords;
     this.filterForAPI = apiFilters.filterForAPI;
 
-    // build filterForUI/URL from the new filterForAPI object
-    this.createFilterForURL();
-
-    this.getPaginatedDocs(this.tableParams.currentPage);
-  }
-
-  createFilterForURL() {
-    // for each key in filterForAPI
-    Object.keys(this.filterForAPI).forEach(key => {
-      this.filterForURL[key] = this.filterForAPI[key];
-    });
-
     this.filterForUI.milestone = this.filterForAPI['milestone'] ? this.filterForAPI['milestone'].split(',') : null;
     this.filterForUI.documentAuthorType = this.filterForAPI['documentAuthorType'] ? this.filterForAPI['documentAuthorType'].split(',') : null;
     this.filterForUI.type = this.filterForAPI['type'] ? this.filterForAPI['type'].split(',') : null;
     this.filterForUI.projectPhase = this.filterForAPI['projectPhase'] ? this.filterForAPI['projectPhase'].split(',') : null;
     this.filterForUI.datePostedStart = this.filterForAPI['datePostedStart'];
     this.filterForUI.datePostedEnd = this.filterForAPI['datePostedEnd'];
+
+    this.getPaginatedDocs(this.tableParams.currentPage);
   }
 
   getPaginatedDocs(pageNumber) {
@@ -349,11 +334,11 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
         if (res[0].data && res[0].data.meta[0]) {
           this.tableParams.totalListItems = res[0].data.meta[0].searchResultsTotal;
           this.documents = res[0].data.searchResults;
-          this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, this.filterForURL, this.tableParams.keywords);
+          this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, this.filterForAPI, this.tableParams.keywords);
         } else {
           this.documents = [];
           this.tableParams.totalListItems = 0;
-          this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, this.filterForURL, this.tableParams.keywords);
+          this.tableTemplateUtils.updateUrl(this.tableParams.sortBy, this.tableParams.currentPage, this.tableParams.pageSize, this.filterForAPI, this.tableParams.keywords);
         }
 
         this.setDocumentRowData();

--- a/src/app/shared/components/table-template/table-template.component.ts
+++ b/src/app/shared/components/table-template/table-template.component.ts
@@ -181,9 +181,12 @@ export class TableTemplateComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   updatePageSize(pageSize) {
+    this.activePageSize = pageSize;
     this.data.paginationData.pageSize = pageSize;
-    this.onPageNumUpdate.emit(pageSize);
-    this.search();
+    // If the user changes the size of the page, we should go
+    // back to the first page, just like if we changed a
+    // query filter/keyword
+    this.updatePageNumber(1);
   }
 
   // Searching and filtering functions


### PR DESCRIPTION
Additional fix for table template to handle "show all" better, automatically re-page to page one. Fix to the project document table to remove override for columnSort (handled by template), and removing unused filterForURL variable.

High priority, as Jess wants these fixes in production ASAP.