### PR TITLE
adding continue-on-error for zap scan

### DIFF
--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -27,6 +27,7 @@ jobs:
   zap_scan:
     runs-on: ubuntu-latest
     name: Zap Scan EPIC Public
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Adding continue-on-error for zap scan. Currently github actions do not allow for checking the container exit code, so we cannot determine warning vs. failure. Because we may not want zap warnings to block our pipeline, we can ignore failures for now.

Note that all zap issues will be added to the repo github issue tracker.