### PR TITLE
Move continue-on-error into step

### DIFF
--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -27,7 +27,6 @@ jobs:
   zap_scan:
     runs-on: ubuntu-latest
     name: Zap Scan EPIC Public
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -35,6 +34,7 @@ jobs:
           ref: develop
       - name: ZAP Scan
         uses: zaproxy/action-baseline@v0.3.0
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'


### PR DESCRIPTION
Accidentally put the continue-on-error at the job level. Should only trigger on the step. Moved the zap scan continue-on-error into the step, not the job itself