### PR TITLE
Display buttons based on item.type

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -52,7 +52,7 @@
                     [routerLink]="['/p', item.project?._id ]" *ngIf="item.project?._id">
                     Project Info
                   </a>
-                  <a *ngIf="item?.pcp" class="btn btn-sm content-btn-alt" title="View this Public Comment Period"
+                  <a *ngIf="item?.pcp && item?.type === 'Public Comment Period'" class="btn btn-sm content-btn-alt" title="View this Public Comment Period"
                     [routerLink]="['/p', item.project?._id, 'cp', item.pcp ]">
                     Submit/ View Comments
                   </a>
@@ -61,7 +61,7 @@
                     target="_blank">
                     View Document(s)
                   </a>
-                  <a *ngIf="item.documentUrl && item?.notificationName"
+                  <a *ngIf="item.documentUrl && item?.notificationName && item?.type === 'Project Notification Public Comment Period'"
                     class="btn btn-sm content-btn-alt" title="View more information" href="{{item.documentUrl}}"
                     target="_blank">
                     View Project Notification Public Comment Period


### PR DESCRIPTION
Ensure the PCP or PN PCP buttons display based on the Activity Post Type, rather than just the existence of the name.

See ticket [EE-1059](https://bcmines.atlassian.net/browse/EE-1059)