### PR TITLE
EE-1087: Adding check for null codes

### DIFF
--- a/src/app/shared/components/table-template/table-template.component.ts
+++ b/src/app/shared/components/table-template/table-template.component.ts
@@ -267,7 +267,7 @@ export class TableTemplateComponent implements OnInit, OnChanges, OnDestroy {
     if (filter.selectedOptions && filter.selectedOptions.length > 0) {
       filtersForAPI[filter.id] = '';
       filter.selectedOptions.forEach(option => {
-        if (option.hasOwnProperty('code')) {
+        if (option.hasOwnProperty('code') && option['code']) {
           filtersForAPI[filter.id] += (filter.id === 'pcp' ? option.code : option.name) + ',';
         } else if (option.hasOwnProperty('_id')) {
           filtersForAPI[filter.id] += option._id + ',';


### PR DESCRIPTION
Proponent was supposed to be using the `_id` for filters, but a null `code` attribute in the model (null for all records) was triggering the logic in the filter tool to assume it was a code value check, not an objectID check.

Added a check in the filter to prevent null code attributes from applying to the filter.

See ticket [EE-1087](https://bcmines.atlassian.net/browse/EE-1087)