### PR TITLE
EE-1114: Fix paging not updating for activities

### DIFF
--- a/src/app/project/project-activites/project-activites.component.html
+++ b/src/app/project/project-activites/project-activites.component.html
@@ -22,11 +22,8 @@
     </div>
 
     <app-table-template *ngIf="!loading && tableParams.totalListItems != 0"
-                        (checkboxChange)='checkChange($event)'
                         [columns]="tableColumns"
                         [data]="tableData"
-                        (onColumnSort)='setColumnSort($event)'
-                        (onSelectedRow)='updateSelectedRow($event)'
                         (onPageNumUpdate)='getPaginatedDocs($event)'>
     </app-table-template>
   </section>

--- a/src/app/project/project-activites/project-activites.component.ts
+++ b/src/app/project/project-activites/project-activites.component.ts
@@ -112,16 +112,6 @@ export class ProjectActivitesComponent implements OnInit, OnDestroy {
     }
   }
 
-
-  setColumnSort(column) {
-    if (this.tableParams.sortBy.charAt(0) === '+') {
-      this.tableParams.sortBy = '-' + column;
-    } else {
-      this.tableParams.sortBy = '+' + column;
-    }
-    this.getPaginatedDocs(this.tableParams.currentPage);
-  }
-
   getPaginatedDocs(pageNumber) {
     // Go to top of page after clicking to a different page.
     window.scrollTo(0, 0);
@@ -129,7 +119,7 @@ export class ProjectActivitesComponent implements OnInit, OnDestroy {
     const params = this.terms.getParams();
     params['ms'] = new Date().getMilliseconds();
     params['dataset'] = this.terms.dataset;
-    params['currentPage'] = this.tableParams.currentPage = pageNumber;
+    params['currentPage'] = pageNumber || this.tableParams.currentPage;
     params['sortBy'] = this.tableParams.sortBy = '-dateAdded';
     params['keywords'] = this.tableParams.keywords;
     params['pageSize'] = this.tableParams.pageSize = 10;

--- a/src/app/shared/components/table-template/table-template.component.ts
+++ b/src/app/shared/components/table-template/table-template.component.ts
@@ -201,8 +201,9 @@ export class TableTemplateComponent implements OnInit, OnChanges, OnDestroy {
 
     // if the current filters/keyword does not match previous filter/keyword
     // reset the page and sortBy back to defaults. Persist the changed values
-    if (this.data.paginationData.previousKeyword !== this.keywords ||
-        JSON.stringify(this.data.paginationData.previousFilters) !== JSON.stringify(newFilters)) {
+
+    if ((this.data.paginationData.previousKeyword != null && this.data.paginationData.previousKeyword !== this.keywords) ||
+       (this.data.paginationData.previousFilters != null && JSON.stringify(this.data.paginationData.previousFilters) !== JSON.stringify(newFilters))) {
       this.data.paginationData.currentPage = 1;
       // for default searches, also include the score. This will bubble
       // the highest related match up to the top, but will only trigger


### PR DESCRIPTION
Activities page was not paging correctly due to an issue in the table component where the previous filter/keywords were `undefined` and triggering a search refresh, which resets the page back to 1. Made a change to the component so it ignores that check if previous filters and keywords are undefined/null.

See ticket [EE-1114](https://bcmines.atlassian.net/browse/EE-1114)