### PR TITLE
NOBUG: Update OpenShift templates

### DIFF
--- a/openshift/templates/angular-builder/angular-builder.json
+++ b/openshift/templates/angular-builder/angular-builder.json
@@ -86,7 +86,7 @@
       "displayName": "Group Name",
       "description": "The name to group all of the frontend objects defined in this template.",
       "required": true,
-      "value": "eagle-public"
+      "value": "eagle-epic"
     },
     {
       "name": "GIT_REPO_URL",

--- a/openshift/templates/angular-on-nginx/angular-on-nginx-build.json
+++ b/openshift/templates/angular-on-nginx/angular-on-nginx-build.json
@@ -99,7 +99,7 @@
       "displayName": "Group Name",
       "description": "The name to group all of the frontend objects defined in this template.",
       "required": true,
-      "value": "eagle-public"
+      "value": "eagle-epic"
     },
     {
       "name": "ANGULAR_BUILDER_IMAGE",

--- a/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
+++ b/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
@@ -92,12 +92,12 @@
                 ],
                 "resources": {
                   "requests": {
-                    "cpu": "${NODEJS_CPU_REQUEST}",
-                    "memory": "${NODEJS_MEMORY_REQUEST}"
+                    "cpu": "${NGINX_CPU_REQUEST}",
+                    "memory": "${NGINX_MEMORY_REQUEST}"
                   },
                   "limits": {
-                    "cpu": "${NODEJS_CPU_LIMIT}",
-                    "memory": "${NODEJS_MEMORY_LIMIT}"
+                    "cpu": "${NGINX_CPU_LIMIT}",
+                    "memory": "${NGINX_MEMORY_LIMIT}"
                   }
                 },
                 "livenessProbe": {
@@ -285,25 +285,25 @@
       "value": ""
     },
     {
-      "name": "NODEJS_CPU_REQUEST",
+      "name": "NGINX_CPU_REQUEST",
       "displayName": "CPU Request",
       "description": "Reserved amount of CPU (in cores) the Node.js container can use.",
       "value": "1m"
     },
     {
-      "name": "NODEJS_MEMORY_REQUEST",
+      "name": "NGINX_MEMORY_REQUEST",
       "displayName": "Memory Request",
       "description": "Reserved amount of memory the Node.js container can use.",
       "value": "80Mi"
     },
     {
-      "name": "NODEJS_CPU_LIMIT",
+      "name": "NGINX_CPU_LIMIT",
       "displayName": "CPU Limit",
       "description": "Maximum amount of CPU (in cores) the Node.js container can use.",
       "value": "10m"
     },
     {
-      "name": "NODEJS_MEMORY_LIMIT",
+      "name": "NGINX_MEMORY_LIMIT",
       "displayName": "Memory Limit",
       "description": "Maximum amount of memory the Node.js container can use.",
       "value": "100Mi"

--- a/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
+++ b/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
@@ -221,7 +221,7 @@
       "displayName": "Group Name",
       "description": "The name to group all of the frontend objects defined in this template.",
       "required": true,
-      "value": "eagle-api"
+      "value": "eagle-epic"
     },
     {
       "name": "IMAGE_NAMESPACE",

--- a/openshift/templates/nginx-runtime/nginx-runtime.json
+++ b/openshift/templates/nginx-runtime/nginx-runtime.json
@@ -71,7 +71,7 @@
       "displayName": "Group Name",
       "description": "The name to group all of the frontend objects defined in this template.",
       "required": true,
-      "value": "eagle-public"
+      "value": "eagle-epic"
     },
     {
       "name": "GIT_REPO_URL",

--- a/openshift/templates/pipeline/eagle-public-pipeline.bc.json
+++ b/openshift/templates/pipeline/eagle-public-pipeline.bc.json
@@ -68,7 +68,7 @@
         "displayName": "Group Name",
         "description": "The name to group all of the objects defined in this template.",
         "required": true,
-        "value": "eagle-public"
+        "value": "eagle-epic"
       },
       {
         "name": "GIT_REPO_URL",


### PR DESCRIPTION
- Changed default `GROUP_NAME` TO `eagle-epic` so the label can be used to capture all `api`, `admin` and `public` deployments instead of just `public`.