### PR TITLE
EPICSYSTEM-117: Fixed logic for PCP badge when no PCP exists

### DIFF
--- a/src/app/models/commentperiod.ts
+++ b/src/app/models/commentperiod.ts
@@ -120,7 +120,10 @@ export class CommentPeriod {
       const dateStarted = moment(obj.dateStarted);
       const dateCompleted = moment(obj.dateCompleted);
 
-      if (moment(now).isBetween(dateStarted, dateCompleted)) {
+      if (moment(now).isBefore(dateStarted)) {
+        this.commentPeriodStatus = 'Pending';
+        this.daysRemaining = 'Pending';
+      } else if (moment(now).isBetween(dateStarted, dateCompleted)) {
         this.commentPeriodStatus = 'Open';
         this.daysRemainingCount = dateCompleted.diff(moment(now), 'days');
         this.daysRemaining = this.daysRemainingCount === 0 ? 'Final Day' : this.daysRemainingCount + (this.daysRemainingCount === 1 ? ' Day ' : ' Days ') + 'Remaining';
@@ -128,8 +131,8 @@ export class CommentPeriod {
         this.commentPeriodStatus = 'Closed';
         this.daysRemaining = 'Completed';
       } else {
-        this.commentPeriodStatus = 'Pending';
-        this.daysRemaining = 'Pending';
+        this.commentPeriodStatus = 'None';
+        this.daysRemaining = 'None';
       }
     }
 

--- a/src/app/project-notifications/project-notification-documents-table-details/project-notification-documents-table-details.component.html
+++ b/src/app/project-notifications/project-notification-documents-table-details/project-notification-documents-table-details.component.html
@@ -70,9 +70,8 @@
                 View Pending Comment Period
             </a>
             <a *ngIf="
-                (rowData.commentPeriod?.commentPeriodStatus === 'Pending' &&
-                !rowData.commentPeriod?.isMet) ||
-                !rowData.commentPeriod?.commentPeriodStatus"
+                rowData.commentPeriod?.commentPeriodStatus === 'Pending' &&
+                !rowData.commentPeriod?.isMet"
                 class="btn btn-primary view-pcp-btn"
                 title="View this Public Comment Period"
             >

--- a/src/app/shared/utils/constants.ts
+++ b/src/app/shared/utils/constants.ts
@@ -42,6 +42,7 @@ export class Constants {
   };
 
   public static readonly PCP_COLLECTION: object[] = [
+    { code: 'none', name: 'None'},
     { code: 'pending', name: 'Pending' },
     { code: 'open', name: 'Open' },
     { code: 'closed', name: 'Closed' }


### PR DESCRIPTION
Some project notifications will not have public comment periods. 
We wanted to not show a PCP badge in project notifications if the PCP does not exist.

Changed default behaviour from `Pending` to `None` so if there is not a PCP, it is not assumed one will be created.
Changed logic to hide the badge if no PCP is created.