### PR TITLE
PUBLIC-107: Project Information drop down UI tweaks

### DIFF
--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -206,25 +206,6 @@
   color: var(--mn-color) !important;
 }
 
-.dropdown-item .dd-item-header {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  white-space: nowrap;
-}
-
-.dropdown-item .icon {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  line-height: 1;
-}
-
-.dropdown-item .icon i {
-  display: block;
-  line-height: 1;
-}
-
 .dropdown-item strong {
   font-weight: var(--bs-font-weight-semibold);
   transition: color 0.2s;

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -24,27 +24,18 @@
             <span>Project Information</span><span class="caret"></span>
           </a>
           <div class="dropdown-menu dropdown-menu-end" aria-labelledby="searchProjects">
-            <a class="dropdown-item" [routerLink]="['/projects-list']" title="List Projects" (click)="closeMenus()">
-              <div class="dd-item-header">
-                <span class="icon align-middle"><i class="material-icons">list</i></span>
-                <strong>List of Projects</strong>
-              </div>
+            <a class="dropdown-item" [routerLink]="['/projects-list']" title="All Projects" (click)="closeMenus()">
+              <strong>All Projects</strong>
               <span class="dd-item-desc">Access all information relating to projects that have been involved with an
                 environmental assessment in British Columbia</span>
             </a>
-            <a class="dropdown-item" [routerLink]="['/project-notifications']" title="Project Notifications"
+            <a class="dropdown-item" [routerLink]="['/project-notifications']" title="All Project Notifications"
               (click)="closeMenus()">
-              <div class="dd-item-header">
-                <span class="icon align-middle"><i class="material-icons">view_list</i></span>
-                <strong>List of Project Notifications</strong>
-              </div>
+              <strong>All Project Notifications</strong>
               <span class="dd-item-desc">Access information related to Project Notifications</span>
             </a>
-            <a class="dropdown-item" [routerLink]="['/search']" title="Search Documents" (click)="closeMenus()">
-              <div class="dd-item-header">
-                <span class="icon align-middle"><i class="material-icons">search</i></span>
-                <strong>All Documents</strong>
-              </div>
+            <a class="dropdown-item" [routerLink]="['/search']" [queryParams]="{tab: 'documents'}" title="All Documents" (click)="closeMenus()">
+              <strong>All Documents</strong>
               <span class="dd-item-desc">Access a list of all documents associated with any projects involved with an
                 environmental assessment in British Columbia</span>
             </a>


### PR DESCRIPTION
## PUBLIC-107: Project Information drop down UI tweaks

### Changes

- **Rename labels**: "List of Projects" → "All Projects", "List of Project Notifications" → "All Project Notifications"
- **Fix navigation**: "All Documents" now navigates to the Documents tab (`/search?tab=documents`) instead of the default Projects tab
- **Remove icons**: Removed material-icons from all three dropdown items
- **CSS cleanup**: Removed unused `.dd-item-header`, `.icon`, `.icon i` rules

### Files Changed

- `src/app/header/header.component.html`
- `src/app/header/header.component.css`